### PR TITLE
Initial commit of the AWS Secrets Manager caching client

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/node": "^12.0.4",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",
+    "aws-sdk-mock": "^4.4.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.3.0",
     "eslint-config-standard": "^12.0.0",
@@ -62,5 +63,9 @@
       "json",
       "node"
     ]
+  },
+  "dependencies": {
+    "aws-sdk": "^2.466.0",
+    "lru-cache": "^5.1.1"
   }
 }

--- a/src/__tests__/cached-secret.test.ts
+++ b/src/__tests__/cached-secret.test.ts
@@ -1,0 +1,127 @@
+import { SecretsManager } from 'aws-sdk'
+import { CachedSecret } from '../cached-secret'
+import { DEFAULT_CACHE_CONFIG } from '../types'
+import { mockSecretsManager, restoreAll } from './test-util'
+
+const exampleVersionId = '01234567890123456789012345678901'
+const exampleVersions = {
+  '01234567890123456789012345678901': ['AWSCURRENT']
+}
+
+const exampleVersionResponse = {
+  SecretString: 'test'
+}
+
+describe('CachedSecret', () => {
+  afterEach(() => {
+    restoreAll()
+  })
+
+  it('allows one to fetch by VersionId', async () => {
+    mockSecretsManager({
+      versions: {
+        '01234567890123456789012345678901': ['NOTCURRENT']
+      },
+      versionResponse: exampleVersionResponse
+    })
+    const client = new SecretsManager()
+    const cache = new CachedSecret({
+      secretId: 'example',
+      client,
+      config: DEFAULT_CACHE_CONFIG
+    })
+
+    const result = await cache.getSecretValue({ versionId: exampleVersionId })
+
+    expect(result).toEqual(exampleVersionResponse)
+  })
+
+  it('allows one to fetch by VersionStage', async () => {
+    mockSecretsManager({
+      versions: {
+        '01234567890123456789012345678901': ['NOTCURRENT']
+      },
+      versionResponse: exampleVersionResponse
+    })
+    const client = new SecretsManager()
+    const cache = new CachedSecret({
+      secretId: 'example',
+      client,
+      config: DEFAULT_CACHE_CONFIG
+    })
+
+    const result = await cache.getSecretValue({ versionStage: 'NOTCURRENT' })
+
+    expect(result).toEqual(exampleVersionResponse)
+  })
+
+  it('returns null if the VersionStage is not present', async () => {
+    mockSecretsManager({
+      versions: exampleVersions,
+      versionResponse: exampleVersionResponse
+    })
+    const client = new SecretsManager()
+    const cache = new CachedSecret({
+      secretId: 'example',
+      client,
+      config: DEFAULT_CACHE_CONFIG
+    })
+
+    const result = await cache.getSecretValue({ versionStage: 'NOTCURRENT' })
+
+    expect(result).toEqual(null)
+  })
+
+  it('caches the response', async () => {
+    mockSecretsManager({
+      versions: exampleVersions,
+      versionResponse: exampleVersionResponse
+    })
+    const client = new SecretsManager()
+    const cache = new CachedSecret({
+      secretId: 'example',
+      client,
+      config: DEFAULT_CACHE_CONFIG
+    })
+
+    const describeSpy = jest.spyOn(client, 'describeSecret')
+    const getSpy = jest.spyOn(client, 'getSecretValue')
+
+    for (let i = 0; i < 10; i++) {
+      const response = await cache.getSecretValue({})
+
+      expect(response).toEqual(exampleVersionResponse)
+    }
+
+    expect(describeSpy).toBeCalledTimes(1)
+    expect(getSpy).toBeCalledTimes(1)
+  })
+
+  it('respects the secretRefreshInterval', async () => {
+    mockSecretsManager({
+      versions: exampleVersions,
+      versionResponse: exampleVersionResponse
+    })
+    const client = new SecretsManager()
+    const cache = new CachedSecret({
+      secretId: 'example',
+      client,
+      config: {
+        ...DEFAULT_CACHE_CONFIG,
+        secretRefreshInterval: 1 // 1ms
+      }
+    })
+
+    const describeSpy = jest.spyOn(client, 'describeSecret')
+    const getSpy = jest.spyOn(client, 'getSecretValue')
+
+    for (let i = 0; i < 10; i++) {
+      const response = await cache.getSecretValue({})
+
+      expect(response).toEqual(exampleVersionResponse)
+    }
+
+    expect(describeSpy.mock.calls.length).toBeGreaterThan(1)
+    expect(getSpy.mock.calls.length).toBeGreaterThan(1)
+  })
+})

--- a/src/__tests__/secrets-cache.test.ts
+++ b/src/__tests__/secrets-cache.test.ts
@@ -1,0 +1,103 @@
+import { SecretsManager } from 'aws-sdk'
+import { SecretsCache } from '../secrets-cache'
+import { mockSecretsManager, restoreAll } from './test-util'
+
+const exampleVersions = {
+  '01234567890123456789012345678901': ['AWSCURRENT']
+}
+
+const exampleVersionResponse = {
+  SecretString: 'test'
+}
+
+describe('SecretsCache', () => {
+  afterEach(() => {
+    restoreAll()
+  })
+
+  it('uses the specified client', async () => {
+    mockSecretsManager({
+      versions: exampleVersions,
+      versionResponse: exampleVersionResponse
+    })
+    const client = new SecretsManager()
+    const cache = new SecretsCache({ client })
+
+    const describeSpy = jest.spyOn(client, 'describeSecret')
+    const getSpy = jest.spyOn(client, 'getSecretValue')
+
+    await cache.getSecretValue('mysecret')
+
+    expect(describeSpy).toBeCalledTimes(1)
+    expect(getSpy).toBeCalledTimes(1)
+  })
+
+  it('fetches the current stage by default', async () => {
+    mockSecretsManager({
+      versions: exampleVersions,
+      versionResponse: exampleVersionResponse
+    })
+    const cache = new SecretsCache()
+
+    const response = await cache.getSecretValue('mySecret')
+
+    expect(response).toEqual(exampleVersionResponse)
+  })
+
+  it('fetches the specified stage', async () => {
+    mockSecretsManager({
+      versions: { '01234567890123456789012345678901': ['NOTCURRENT'] },
+      versionResponse: exampleVersionResponse
+    })
+    const cache = new SecretsCache()
+
+    const response = await cache.getSecretValue('mySecret', { versionStage: 'NOTCURRENT' })
+
+    expect(response).toEqual(exampleVersionResponse)
+  })
+
+  it('returns null if the requested VersionStage does not exist', async () => {
+    mockSecretsManager({
+      versions: { '01234567890123456789012345678901': ['NOTCURRENT'] },
+      versionResponse: exampleVersionResponse
+    })
+    const cache = new SecretsCache()
+
+    const response = await cache.getSecretValue('mySecret')
+
+    expect(response).toBe(null)
+  })
+
+  it('returns null if there are no versions', async () => {
+    mockSecretsManager({
+      versions: {},
+      versionResponse: exampleVersionResponse
+    })
+    const cache = new SecretsCache()
+
+    const response = await cache.getSecretValue('mySecret')
+
+    expect(response).toBe(null)
+  })
+
+  it('reuses the cached version', async () => {
+    mockSecretsManager({
+      versions: exampleVersions,
+      versionResponse: exampleVersionResponse
+    })
+    const client = new SecretsManager()
+    const cache = new SecretsCache({ client })
+
+    const describeSpy = jest.spyOn(client, 'describeSecret')
+    const getSpy = jest.spyOn(client, 'getSecretValue')
+
+    for (let i = 0; i < 10; i++) {
+      const response = await cache.getSecretValue('mySecret')
+
+      expect(response).toEqual(exampleVersionResponse)
+    }
+
+    expect(describeSpy).toBeCalledTimes(1)
+    expect(getSpy).toBeCalledTimes(1)
+  })
+})

--- a/src/__tests__/test-util.ts
+++ b/src/__tests__/test-util.ts
@@ -1,0 +1,19 @@
+import * as AWS from 'aws-sdk-mock'
+
+interface MockArgs {
+  versions: { [key: string]: string[] }
+  versionResponse: {
+    SecretString: string
+  }
+}
+
+export function mockSecretsManager({ versions, versionResponse }: MockArgs): void {
+  AWS.mock('SecretsManager', 'describeSecret', {
+    VersionIdsToStages: versions
+  })
+  AWS.mock('SecretsManager', 'getSecretValue', versionResponse)
+}
+
+export function restoreAll(): void {
+  AWS.restore()
+}

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -1,0 +1,13 @@
+import { randomlyChooseTtl } from '../util'
+
+describe('util', () => {
+  describe('randomlyChooseTtl', () => {
+    it('chooses a ttl no less than half of the maxTtl provided', () => {
+      const maxTtl = 20
+      const expectedMin = 10
+      for (let i = 0; i < 20; i++) {
+        expect(randomlyChooseTtl(maxTtl)).toBeGreaterThanOrEqual(expectedMin)
+      }
+    })
+  })
+})

--- a/src/cached-secret-version.ts
+++ b/src/cached-secret-version.ts
@@ -1,0 +1,77 @@
+import { SecretsManager } from 'aws-sdk'
+import { GetSecretValueResponse } from 'aws-sdk/clients/secretsmanager'
+import { CacheConfig } from './types'
+import { randomlyChooseTtl } from './util'
+
+interface CachedSecretVersionArgs {
+  client: Pick<SecretsManager, 'getSecretValue'>
+  config: CacheConfig
+  secretId: string
+  versionId: string
+}
+
+/**
+ * This is a cache for a particular VersionId of a secret
+ *
+ * VersionIds contain the actual value for a particular GetSecretValue response
+ */
+export class CachedSecretVersion {
+  private _config: CacheConfig
+  private _client: Pick<SecretsManager, 'getSecretValue'>
+
+  private _secretId: string
+  private _versionId?: string
+
+  private _secretValue?: GetSecretValueResponse
+  private _nextRefreshTime: number
+
+  public constructor(args: CachedSecretVersionArgs) {
+    this._client = args.client
+    this._config = args.config
+    this._secretId = args.secretId
+    this._versionId = args.versionId
+
+    this._nextRefreshTime = Date.now() - 1
+  }
+
+  /**
+   * Checks the cache for a non-stale secret value and, failing that, fetches a new copy
+   */
+  public async getSecretValue(): Promise<GetSecretValueResponse | null> {
+    if (Date.now() > this._nextRefreshTime) {
+      await this._refreshSecretValue()
+    }
+
+    if (!this._secretValue) {
+      return null
+    }
+    return { ...this._secretValue }
+  }
+
+  /**
+   * Calls SecretsManager.GetSecretValue, caches the result, and resets the next refresh time
+   *
+   * TODO Implement retry/backoff logic
+   */
+  private async _refreshSecretValue(): Promise<void> {
+    const result = await this._client
+      .getSecretValue({
+        SecretId: this._secretId,
+        VersionId: this._versionId
+      })
+      .promise()
+    this._secretValue = result
+
+    this._resetRefreshTime()
+  }
+
+  /**
+   * Sets _nextRefreshTime to a random time somewhere in the latter half of the interval set in
+   * config.secretRefreshInterval
+   */
+  private _resetRefreshTime(): void {
+    const maxTtl = this._config.secretRefreshInterval
+    const ttl = randomlyChooseTtl(maxTtl)
+    this._nextRefreshTime = Date.now() + ttl
+  }
+}

--- a/src/cached-secret.ts
+++ b/src/cached-secret.ts
@@ -1,0 +1,177 @@
+import LRU from 'lru-cache'
+import { SecretsManager } from 'aws-sdk'
+import { GetSecretValueResponse } from 'aws-sdk/clients/secretsmanager'
+import { CacheConfig } from './types'
+import { CachedSecretVersion } from './cached-secret-version'
+import { randomlyChooseTtl } from './util'
+
+const MAX_VERSIONS_CACHE = 10
+
+interface CachedSecretArgs {
+  secretId: string
+  client: Pick<SecretsManager, 'describeSecret' | 'getSecretValue'>
+  config: CacheConfig
+}
+
+interface GetSecretValueOpts {
+  versionId?: string
+  versionStage?: string
+}
+
+interface StringHashMap {
+  [key: string]: string
+}
+
+/**
+ * A CachedSecret represents a single SecretId in AWS SecretsManager
+ *
+ * == Rules
+ *
+ * * Secrets can have many versions
+ * * Secrets can have many stages (AWSCURRENT, AWSPREVIOUS, AWSPENDING, etc)
+ * * A stage maps to one version
+ * * A version can map to many stages
+ *
+ * == Basic Example
+ *
+ * > const cachedSecret = new CachedSecret({
+ *     secretId: 'mySuperTopSecret',
+ *     client: new AWS.SecretsManager(),
+ *     config: {
+ *       secretRefreshInterval: 60 * 5 * 1000,
+ *       ...
+ *     }
+ *   })
+ * // Fetch the default AWSCURRENT value
+ * > const secretValue = await cachedSecret.getSecretValue()
+ * {
+ *   SecretString: '{"username":"myUsername","password":"s00perSekret"}',
+ *   ...
+ * }
+ */
+export class CachedSecret {
+  private _secretId: string
+  private _client: Pick<SecretsManager, 'describeSecret' | 'getSecretValue'>
+  private _config: CacheConfig
+
+  private _versionIdsByStage: StringHashMap
+  private _nextRefreshTime: number
+
+  private _versionCache: LRU<string, CachedSecretVersion>
+
+  public constructor(args: CachedSecretArgs) {
+    this._config = args.config
+    this._client = args.client
+    this._secretId = args.secretId
+
+    this._versionIdsByStage = {}
+    this._versionCache = new LRU<string, CachedSecretVersion>(MAX_VERSIONS_CACHE)
+    this._nextRefreshTime = Date.now() - 1
+  }
+
+  /**
+   * Fetch the current value, optionally for the provided versionStage or versionId
+   *
+   * // Fetch for versionStage AWSCURRENT
+   * > const secretValue = await cachedSecret.getSecretValue()
+   *
+   * // Fetch a specific versionStage
+   * > const secretValue = await cachedSecret.getSecretValue({ versionStage: 'AWSCURRENT' })
+   *
+   * // Fetch a specific versionId
+   * > const secretValue = await cachedSecret.getSecretValue({ versionId: '123456' })
+   */
+  public async getSecretValue(
+    opts: GetSecretValueOpts = {}
+  ): Promise<GetSecretValueResponse | null> {
+    const { versionId, versionStage } = opts
+    if (versionId) {
+      const version = await this._getVersionById(versionId)
+
+      return version.getSecretValue()
+    }
+
+    const version = await this._getVersionForStage(versionStage || this._config.defaultVersionStage)
+    if (!version) {
+      return null
+    }
+
+    return version.getSecretValue()
+  }
+
+  private async _getVersionForStage(versionStage: string): Promise<CachedSecretVersion | null> {
+    const versionId = await this._getVersionIdForStage(versionStage)
+
+    if (!versionId) {
+      return null
+    }
+
+    return this._getVersionById(versionId)
+  }
+
+  private async _getVersionById(versionId: string): Promise<CachedSecretVersion> {
+    const existing = this._versionCache.get(versionId)
+    if (existing) {
+      return existing
+    }
+
+    // The versionId is new to us, meaning a rotation is probably scheduled to happen soon
+    const version = new CachedSecretVersion({
+      client: this._client,
+      config: this._config,
+      secretId: this._secretId,
+      versionId
+    })
+
+    this._versionCache.set(versionId, version)
+
+    return version
+  }
+
+  private async _getVersionIdForStage(versionStage: string): Promise<string | null> {
+    if (Date.now() > this._nextRefreshTime) {
+      await this._refreshVersions()
+    }
+
+    return this._versionIdsByStage[versionStage] || null
+  }
+
+  private async _refreshVersions(): Promise<void> {
+    const result = await this._client.describeSecret({ SecretId: this._secretId }).promise()
+
+    if (!result.VersionIdsToStages) {
+      // This secret has no versions attached to it
+      // TODO Decide if we should _resetRefreshTime here
+      // TODO Decide if we should be throwing an exception here
+      this._versionIdsByStage = {}
+      return
+    }
+
+    const versionIdsByStage: StringHashMap = {}
+
+    Object.keys(result.VersionIdsToStages).forEach(
+      (versionId): void => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const stages = result.VersionIdsToStages![versionId]
+        if (!stages) {
+          return
+        }
+
+        stages.forEach(
+          (stage): void => {
+            versionIdsByStage[stage] = versionId
+          }
+        )
+      }
+    )
+
+    this._versionIdsByStage = versionIdsByStage
+    this._resetRefreshTime()
+  }
+
+  private _resetRefreshTime(): void {
+    const maxTtl = this._config.secretRefreshInterval
+    const ttl = randomlyChooseTtl(maxTtl)
+    this._nextRefreshTime = Date.now() + ttl
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,1 @@
-/**
- * Generates a warm welcome to the package
- * @param {string} name the name of the greeting recipient. Defaults to 'World'
- * @return {string} the warm welcome
- */
-export function sayHello(name: string = 'World'): string {
-  return `Hello, ${name}`
-}
+export * from './secrets-cache'

--- a/src/secrets-cache.ts
+++ b/src/secrets-cache.ts
@@ -1,0 +1,93 @@
+import LRU from 'lru-cache'
+import { SecretsManager } from 'aws-sdk'
+import { GetSecretValueResponse } from 'aws-sdk/clients/secretsmanager'
+import { CachedSecret } from './cached-secret'
+import { CacheConfig, DEFAULT_CACHE_CONFIG } from './types'
+
+interface SecretsCacheOpts {
+  client: Pick<SecretsManager, 'describeSecret' | 'getSecretValue'>
+  config: CacheConfig
+}
+
+interface GetSecretValueOpts {
+  versionId?: string
+  versionStage?: string
+}
+
+/**
+ * Provides a read-only cache store for fetching secrets stored in AWS Secrets Manager
+ *
+ * == Basic Usage
+ *
+ * > const cache = new SecretsCache()
+ *
+ * // Fetch the default AWSCURRENT version
+ * > const secret = await cache.getSecretValue({ SecretId: 'mySecret' })
+ * {
+ *   ARN: 'arn:aws:...',
+ *   SecretString: '...',
+ *   ...
+ * }
+ *
+ * // Fetch a specific VersionStage
+ * > const secret = await cache.getSecretValue(
+ *   'mySecret',
+ *   { versionStage: 'AWSPREVIOUS' }
+ * })
+ *
+ * == Call Flow
+ *
+ * 1. find or initialize a CachedSecret for the secretId
+ * 2. call DescribeSecret to retrieve a list of VersionStagesByVersionId (or use the cache)
+ * 3. find or initialize the CachedSecretVersion for the needed versionId
+ * 4. call GetSecretValue for the needed versionId (or use the cache)
+ *
+ * == Caches
+ *
+ * There are four major caches to be aware of inside of the system:
+ * 1. SecretsCache (this package) caches up to config.maxCacheSize CachedSecret objects
+ * 2. CachedSecret caches the most recent DescribeSecret's VersionStagesByVersionId response
+ * 3. CachedSecret caches up to 10 CachedSecretVersion objects (this should be more than sufficient)
+ * 4. CachedSecretValue caches the most recent GetSecretValue response
+ *
+ * == AWS Permissions Required
+ * * secretsmanager:DescribeSecret
+ * * secretsmanager:GetSecretValue
+ *
+ */
+export class SecretsCache {
+  private _client: Pick<SecretsManager, 'describeSecret' | 'getSecretValue'>
+  private _cache: LRU<string, CachedSecret>
+  private _config: CacheConfig
+
+  public constructor(opts: Partial<SecretsCacheOpts> = {}) {
+    this._client = opts.client || new SecretsManager()
+    this._config = { ...DEFAULT_CACHE_CONFIG, ...opts.config }
+    this._cache = new LRU<string, CachedSecret>(this._config.maxCacheSize)
+  }
+
+  /**
+   * Uses the cached response for SecretsManager.GetSecretValue
+   *
+   * @param request the request as you would normally use when calling SecretsManager.GetSecretValue
+   */
+  public async getSecretValue(
+    secretId: string,
+    opts: GetSecretValueOpts = {}
+  ): Promise<GetSecretValueResponse | null> {
+    const existing = this._cache.get(secretId)
+    if (existing) {
+      return existing.getSecretValue(opts)
+    }
+
+    const secret = new CachedSecret({
+      client: this._client,
+      config: this._config,
+      secretId
+    })
+
+    this._cache.set(secretId, secret)
+
+    return secret.getSecretValue(opts)
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,23 @@
+export const AWSCURRENT = 'AWSCURRENT'
+export const AWSPENDING = 'AWSPENDING'
+export const AWSPREVIOUS = 'AWSPREVIOUS'
+
+export interface CacheConfig {
+  maxCacheSize: number
+  secretRefreshInterval: number
+  defaultVersionStage: 'AWSCURRENT'
+  // TODO implement retry/backoff logic
+  exceptionRetryDelayBase: number
+  exceptionRetryDelayMax: number
+  exceptionRetryGrowthFactor: number
+}
+
+// https://github.com/aws/aws-secretsmanager-caching-python/blob/master/src/aws_secretsmanager_caching/config.py
+export const DEFAULT_CACHE_CONFIG: CacheConfig = {
+  maxCacheSize: 1024,
+  exceptionRetryDelayBase: 1,
+  exceptionRetryGrowthFactor: 2,
+  exceptionRetryDelayMax: 3600,
+  defaultVersionStage: AWSCURRENT,
+  secretRefreshInterval: 60 * 60 * 1000 // 1 hour
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,18 @@
+/**
+ * Randomly chooses a future timestamp in ms based on the ttl provided
+ *
+ * The value chosen should have enough jitter to it that not all instances of an application hammer
+ * the AWS endpoint at the same time
+ *
+ * Rules
+ * * the lower interval bound must be no more than about half the max value
+ * * the upper interval bound must be no more than the ttl provided
+ *
+ * @param ttl The upper bound of milliseconds permitted
+ * @return the ttl chosen
+ */
+export function randomlyChooseTtl(ttl: number): number {
+  // Aim to have the refresh happen in the latter half between now and the TTL
+  const midTtl = Math.floor(ttl / 2)
+  return midTtl + Math.random() * midTtl
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,6 +290,35 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
+  integrity sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.1.0", "@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  integrity sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.1.tgz#e88c53fbd9d91ad9f0f2b0140c16c7c107fe0d07"
+  integrity sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash "^4.17.11"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/babel__core@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"
@@ -541,6 +570,11 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
+
 array-includes@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
@@ -590,6 +624,30 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+aws-sdk-mock@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk-mock/-/aws-sdk-mock-4.4.0.tgz#90f27b6a4e19293e9ad8c25add8e7137c2db94ce"
+  integrity sha512-cnR2Sff2jSO2UazeGL3rp4ulg66I8mVeCWvKZk0Bb+s//b5sUDZ1OhvOqr7v6uRJKhgaikeZJdZtI6efHYsN2Q==
+  dependencies:
+    aws-sdk "^2.431.0"
+    sinon "^7.3.1"
+    traverse "^0.6.6"
+
+aws-sdk@^2.431.0, aws-sdk@^2.466.0:
+  version "2.466.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.466.0.tgz#02d819c5af058e15fd1942296ed3b1def9f4b14d"
+  integrity sha512-dWFpz774ONjP1Cb19VkLOfQSVTu5p5/uncZGovAe71NOfPGDSvrQKXOsKcuI1/k4oJyKW9z/GATF8ht8DkDWGg==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -642,6 +700,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 base@^0.11.1:
   version "0.11.2"
@@ -717,6 +780,15 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -1047,6 +1119,11 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -1369,6 +1446,11 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 exec-sh@^0.3.2:
   version "0.3.2"
@@ -1781,6 +1863,16 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
+ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ignore-walk@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
@@ -2027,6 +2119,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -2452,6 +2549,11 @@ jest@^24.8.0:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
 
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2555,6 +2657,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -2701,12 +2808,29 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+
+lolex@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.0.1.tgz#4a99c2251579d693c6a083446dae0e5c3844d3fa"
+  integrity sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw==
+
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 make-dir@^2.1.0:
   version "2.1.0"
@@ -2916,6 +3040,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.10.tgz#ae46a09a26436fae91a38a60919356ae6db143b6"
+  integrity sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3248,6 +3383,13 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
@@ -3371,6 +3513,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3385,6 +3532,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 ramda@0.25.0:
   version "0.25.0"
@@ -3677,7 +3829,12 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@^1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -3743,6 +3900,19 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+sinon@^7.3.1:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.2.tgz#82dba3a6d85f6d2181e1eca2c10d8657c2161f28"
+  integrity sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.1"
+    diff "^3.5.0"
+    lolex "^4.0.1"
+    nise "^1.4.10"
+    supports-color "^5.5.0"
 
 sisteransi@^1.0.0:
   version "1.0.0"
@@ -3975,7 +4145,7 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -4107,6 +4277,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+traverse@^0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
+  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -4169,6 +4344,11 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 typescript@^3.5.0:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
@@ -4212,6 +4392,14 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -4230,7 +4418,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -4370,6 +4558,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
AWS provides a SecretsManager cache for Go, Python, Java, etc but left JavaScript out of the party. This commit remedies this and could potentially be open sourced/contributed to AWS for care and feeding.

Inspiration: https://github.com/aws/aws-secretsmanager-caching-python