### PR TITLE
fix: Expose SecretsCacheConfig for consumption by consumers

### DIFF
--- a/src/__tests__/secrets-cache.test.ts
+++ b/src/__tests__/secrets-cache.test.ts
@@ -100,4 +100,25 @@ describe('SecretsCache', () => {
     expect(describeSpy).toBeCalledTimes(1)
     expect(getSpy).toBeCalledTimes(1)
   })
+
+  it('ignores the cached values with force: true', async () => {
+    mockSecretsManager({
+      versions: exampleVersions,
+      versionResponse: exampleVersionResponse
+    })
+    const client = new SecretsManager()
+    const cache = new SecretsCache({ client })
+
+    const describeSpy = jest.spyOn(client, 'describeSecret')
+    const getSpy = jest.spyOn(client, 'getSecretValue')
+
+    for (let i = 0; i < 3; i++) {
+      const response = await cache.getSecretValue('mySecret', { force: true })
+
+      expect(response).toEqual(exampleVersionResponse)
+    }
+
+    expect(describeSpy).toBeCalledTimes(3)
+    expect(getSpy).toBeCalledTimes(3)
+  })
 })

--- a/src/cached-secret-version.ts
+++ b/src/cached-secret-version.ts
@@ -10,6 +10,10 @@ interface CachedSecretVersionArgs {
   versionId: string
 }
 
+interface GetSecretValueInput {
+  force?: boolean
+}
+
 /**
  * This is a cache for a particular VersionId of a secret
  *
@@ -37,8 +41,10 @@ export class CachedSecretVersion {
   /**
    * Checks the cache for a non-stale secret value and, failing that, fetches a new copy
    */
-  public async getSecretValue(): Promise<GetSecretValueResponse | null> {
-    if (Date.now() > this._nextRefreshTime) {
+  public async getSecretValue(
+    opts: GetSecretValueInput = {}
+  ): Promise<GetSecretValueResponse | null> {
+    if (opts.force || Date.now() > this._nextRefreshTime) {
       await this._refreshSecretValue()
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,2 @@
-import { CacheConfig } from './types'
-export { SecretsCache } from './secrets-cache'
-
-export type SecretsCacheOptions = Partial<CacheConfig>
+export { SecretsCache, SecretsCacheOptions } from './secrets-cache'
+export { CacheConfig } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
+import { CacheConfig } from './types'
 export { SecretsCache } from './secrets-cache'
-export { CacheConfig as SecretsCacheConfig } from './types'
+
+export type SecretsCacheOptions = Partial<CacheConfig>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { SecretsCache, SecretsCacheOptions } from './secrets-cache'
+export { GetSecretValueOptions, SecretsCache, SecretsCacheOptions } from './secrets-cache'
 export { CacheConfig } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export * from './secrets-cache'
+export { SecretsCache } from './secrets-cache'
+export { CacheConfig as SecretsCacheConfig } from './types'

--- a/src/secrets-cache.ts
+++ b/src/secrets-cache.ts
@@ -4,9 +4,10 @@ import { GetSecretValueResponse } from 'aws-sdk/clients/secretsmanager'
 import { CachedSecret } from './cached-secret'
 import { CacheConfig, DEFAULT_CACHE_CONFIG } from './types'
 
-interface SecretsCacheOpts {
-  client: Pick<SecretsManager, 'describeSecret' | 'getSecretValue'>
-  config: CacheConfig
+export interface SecretsCacheOptions {
+  client?: Pick<SecretsManager, 'describeSecret' | 'getSecretValue'>
+  config?: Partial<CacheConfig>
+  force?: boolean
 }
 
 interface GetSecretValueOpts {
@@ -60,7 +61,7 @@ export class SecretsCache {
   private _cache: LRU<string, CachedSecret>
   private _config: CacheConfig
 
-  public constructor(opts: Partial<SecretsCacheOpts> = {}) {
+  public constructor(opts: SecretsCacheOptions = {}) {
     this._client = opts.client || new SecretsManager()
     this._config = { ...DEFAULT_CACHE_CONFIG, ...opts.config }
     this._cache = new LRU<string, CachedSecret>(this._config.maxCacheSize)

--- a/src/secrets-cache.ts
+++ b/src/secrets-cache.ts
@@ -9,14 +9,28 @@ export interface SecretsCacheOptions {
   config?: Partial<CacheConfig>
 }
 
-interface GetSecretValueOpts {
-  versionId?: string
-  versionStage?: string
+interface BaseGetSecretValueOptions {
   /**
    * Force a cache miss and call AWS Secrets Manager to fetch the value. Defaults to false
    */
   force?: boolean
 }
+
+interface GetSecretValueByIdInput extends BaseGetSecretValueOptions {
+  /**
+   * Use the VersionId in AWS Secrets Manager. NOTE: takes precedence over VersionStage
+   */
+  versionId: string
+}
+
+interface GetSecretValueByStageOptions extends BaseGetSecretValueOptions {
+  /**
+   * Use the version mapped to VersionStage in AWS Secrets Manager. Defaults to AWSCURRENT
+   */
+  versionStage?: string
+}
+
+export type GetSecretValueOptions = GetSecretValueByIdInput | GetSecretValueByStageOptions
 
 /**
  * Provides a read-only cache store for fetching secrets stored in AWS Secrets Manager
@@ -77,7 +91,7 @@ export class SecretsCache {
    */
   public async getSecretValue(
     secretId: string,
-    opts: GetSecretValueOpts = {}
+    opts: GetSecretValueOptions = {}
   ): Promise<GetSecretValueResponse | null> {
     const existing = this._cache.get(secretId)
     if (existing) {

--- a/src/secrets-cache.ts
+++ b/src/secrets-cache.ts
@@ -7,12 +7,15 @@ import { CacheConfig, DEFAULT_CACHE_CONFIG } from './types'
 export interface SecretsCacheOptions {
   client?: Pick<SecretsManager, 'describeSecret' | 'getSecretValue'>
   config?: Partial<CacheConfig>
-  force?: boolean
 }
 
 interface GetSecretValueOpts {
   versionId?: string
   versionStage?: string
+  /**
+   * Force a cache miss and call AWS Secrets Manager to fetch the value. Defaults to false
+   */
+  force?: boolean
 }
 
 /**
@@ -70,7 +73,7 @@ export class SecretsCache {
   /**
    * Uses the cached response for SecretsManager.GetSecretValue
    *
-   * @param request the request as you would normally use when calling SecretsManager.GetSecretValue
+   * @param secretId the name or ARN of the secret as expected by GetSecretValue.SecretId
    */
   public async getSecretValue(
     secretId: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export const AWSPREVIOUS = 'AWSPREVIOUS'
 export interface CacheConfig {
   maxCacheSize: number
   secretRefreshInterval: number
-  defaultVersionStage: 'AWSCURRENT'
+  defaultVersionStage: string
   // TODO implement retry/backoff logic
   exceptionRetryDelayBase: number
   exceptionRetryDelayMax: number


### PR DESCRIPTION
* export the CacheConfig from types as SecretsCacheConfig
* Tighten up exports to be explicit about what should be available to consuming packages